### PR TITLE
Added additional functions to CustomConsole

### DIFF
--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -6,9 +6,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @flow
- */
-/* global stream$Writable */
-/* global tty$WriteStream */
+ *
+ * global stream$Writable, tty$WriteStream */
 
 import type {LogType, LogMessage} from 'types/Console';
 
@@ -37,9 +36,10 @@ class CustomConsole extends Console {
 
     // If we can find the width of the console, do so. Default to 80. This
     // value is used to calculate the table width.
-    this._outWidth = 80;
-    if (stdout instanceof tty$WriteStream) {
-      this._outWidth = (stdout: tty$WriteStream).columns;
+    try {
+      this._outWidth = (((stdout: any): tty$WriteStream).columns: number);
+    } catch (e) {
+      this._outWidth = 80;
     }
   }
 

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -20,6 +20,9 @@ type Formatter = (type: LogType, message: LogMessage) => string;
 class CustomConsole extends Console {
   _stdout: stream$Writable;
   _formatBuffer: Formatter;
+  _groupLevel: int;
+  _counts: Object;
+  _outWidth: int;
 
   constructor(
     stdout: stream$Writable,
@@ -28,27 +31,111 @@ class CustomConsole extends Console {
   ) {
     super(stdout, stderr);
     this._formatBuffer = formatBuffer || ((type, message) => message);
+    this._groupLevel = 0;
+    this._counts = {};
+    this._outWidth = stdout.columns;
   }
 
   _log(type: LogType, message: string) {
     clearLine(this._stdout);
-    super.log(this._formatBuffer(type, message));
+    const groupIndentation = ' > '.repeat(this._groupLevel);
+    super.log(`${groupIndentation}${this._formatBuffer(type, message)}`);
   }
 
-  log(...args: Array<mixed>) {
-    this._log('log', format.apply(null, arguments));
+  assert(assertion: boolean, ...args: Array<mixed>) {
+    if (assertion) {this.log(...args);}
+  }
+
+  clear() {}
+
+  count(label: ?string = '<no label>') {
+    if (!this._counts[label]) {this._counts[label] = 0;}
+    this._counts[label]++;
+    this._log('log', `${label}: ${this._counts[label]}`);
+  }
+
+  error(...args: Array<mixed>) {
+    this._log('error', format.apply(null, arguments));
+  }
+
+  group(label: ?string) {
+    this._groupLevel++;
+    if (label) {this.log(label);}
+  }
+
+  groupCollapsed() {
+    this.group();
+  }
+
+  groupEnd() {
+    this._groupLevel--;
   }
 
   info(...args: Array<mixed>) {
     this._log('info', format.apply(null, arguments));
   }
 
-  warn(...args: Array<mixed>) {
-    this._log('warn', format.apply(null, arguments));
+  table(data: ?object, columns: ?Array<mixed>) {
+    if (typeof data !== 'object') {return;}
+
+    // Right pad a string to match the given width or truncate it if it is too
+    // long.
+    const pad = (data: string, width: int) => {
+      if (data.length > width) {
+        return data.substring(0, width);
+      }
+      return data + ' '.repeat(width - data.toString().length);
+    };
+
+    // Find the maximum value of an array using the given evaluator.
+    const max = (arr: array, evaluator: Function) => {
+      let maxEval = null;
+      for (const el of arr) {
+        const evaluatedValue = evaluator(el);
+        maxEval = maxEval === null ? evaluatedValue :
+          Math.max(maxEval, evaluatedValue);
+      }
+      return maxEval;
+    };
+
+    // Converts any data to a readable string
+    const stringify = value => JSON.stringify(value).replace(/\n/g, '');
+
+    // Determine the maximum length of the keys and values on the object
+    const keys = Object.keys(data);
+    const maxKeyLen = max(keys, el => stringify(el).length);
+    const maxValueWidth = max(Object.values(data), el => stringify(el).length);
+
+    let keyWidth = Math.max(maxKeyLen, '(index)'.length);
+    let valueWidth = Math.max(maxValueWidth, 'Value'.length);
+    let totalTableWidth = keyWidth + valueWidth + 7;
+
+    // Make the table fit in the width of the window
+    while (totalTableWidth > this._outWidth) {
+      if (valueWidth > keyWidth) {valueWidth--;} else {keyWidth--;}
+      totalTableWidth = keyWidth + valueWidth + 7;
+    }
+
+    const keyHeader = pad('(index)', keyWidth);
+    const valueHeader = pad('Value', valueWidth);
+
+    // Draw the actual table
+    this.log('_'.repeat(totalTableWidth));
+    this.log(`| ${keyHeader} | ${valueHeader} |`);
+    this.log('-'.repeat(totalTableWidth));
+    for (const key of keys) {
+      const value = stringify(data[key]);
+      this.log(`| ${pad(key, keyWidth)} | ${pad(value, valueWidth)} |`);
+    }
+    this.log('‾'.repeat(totalTableWidth));
   }
 
-  error(...args: Array<mixed>) {
-    this._log('error', format.apply(null, arguments));
+  log(...args: Array<mixed>) {
+    this._log('log', format.apply(null, arguments));
+  }
+
+  warn(...args: Array<mixed>) {
+    this._log('warn', format.apply(null, arguments));
   }
 
   getBuffer() {

--- a/packages/jest-util/src/__tests__/console.test.js
+++ b/packages/jest-util/src/__tests__/console.test.js
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const CustomConsole = require('../Console');
+
+describe('CustomConsole', () => {
+  let _console;
+  let consoleOutput = '';
+
+  beforeEach(() => {
+    // Initialise the console and override the console.log function to keep
+    // track of the output.
+    _console = new CustomConsole(process.stdout, process.stderr);
+
+    _console._log = (type, ...args) => {
+      const typeChar = {
+        error: 'E',
+        info: 'I',
+        log: 'L',
+        warn: 'W',
+      };
+      const indentation = _console._generateIndentation();
+      consoleOutput += `${typeChar[type]}: ${indentation}${args.join(', ')}\n`;
+    };
+    consoleOutput = '';
+  });
+
+  describe('inherited functions', () => {
+    // These functions should be inherited from Console. Make sure they do
+    // exist.
+    it('should exist', () => {
+      expect(typeof _console.dir).toBe('function');
+      expect(typeof _console.time).toBe('function');
+      expect(typeof _console.timeEnd).toBe('function');
+      expect(typeof _console.trace).toBe('function');
+    });
+  });
+
+  describe('assert', () => {
+    it('should log the given text if the assertion is false', () => {
+      _console.assert(false, '1');
+      _console.assert(1 < 0, '2');
+      expect(consoleOutput).toBe('L: 1\nL: 2\n');
+    });
+
+    it('should not log the given text if the assertion is true', () => {
+      _console.assert(true, '1');
+      _console.assert(1 > 0, '2');
+      expect(consoleOutput).toBe('');
+    });
+  });
+
+  describe('count', () => {
+    it('should output the number of times count has been called', () => {
+      _console.count();
+      _console.count();
+      expect(consoleOutput).toBe('L: <no label>: 1\nL: <no label>: 2\n');
+    });
+
+    it('should output the number of times count() has been called with a certain label', () => {
+      _console.count();
+      _console.count('label1');
+      _console.count('label1');
+      _console.count();
+      _console.count('label1');
+      _console.count('label2');
+      _console.count('label2');
+      _console.count('label1');
+      expect(consoleOutput).toBe(
+        [
+          'L: <no label>: 1',
+          'L: label1: 1',
+          'L: label1: 2',
+          'L: <no label>: 2',
+          'L: label1: 3',
+          'L: label2: 1',
+          'L: label2: 2',
+          'L: label1: 4',
+        ].join('\n') + '\n',
+      );
+    });
+  });
+
+  describe('error/exception', () => {
+    it('should output the error', () => {
+      _console.error('bad things happened');
+      _console.exception('bad things happened');
+      expect(consoleOutput).toBe(
+        ['E: bad things happened', 'E: bad things happened'].join('\n') + '\n',
+      );
+    });
+
+    it('should output all of the arguments passed in', () => {
+      _console.error('bad things happened', 'more bad things');
+      _console.error({error: 'this is', very: 'bad'}, '~ Yoda', 1);
+      expect(consoleOutput).toBe(
+        [
+          'E: bad things happened more bad things',
+          "E: { error: 'this is', very: 'bad' } '~ Yoda' 1",
+        ].join('\n') + '\n',
+      );
+    });
+  });
+
+  describe('group/groupCollapsed/groupEnd', () => {
+    it('should indent the logs one level', () => {
+      _console.log('This is the outer level');
+      _console.group();
+      _console.log('Level 2');
+      _console.group();
+      _console.log('Level 3');
+      _console.warn('More of level 3');
+      _console.groupEnd();
+      _console.log('Back to level 2');
+      _console.groupCollapsed();
+      _console.log('Inside collapsed');
+      _console.groupEnd();
+      _console.groupEnd();
+      _console.log('Back to the outer level');
+
+      expect(consoleOutput).toBe(
+        [
+          'L: This is the outer level',
+          'L: > Level 2',
+          'L: > > Level 3',
+          'W: > > More of level 3',
+          'L: > Back to level 2',
+          'L: > > Inside collapsed',
+          'L: Back to the outer level',
+        ].join('\n') + '\n',
+      );
+    });
+
+    it('should print the label, if given', () => {
+      _console.log('This is the outer level');
+      _console.group('Group 1');
+      _console.log('Level 2');
+      _console.group('Group 2');
+      _console.log('Level 3');
+      _console.warn('More of level 3');
+      _console.groupEnd();
+      _console.log('Back to level 2');
+      _console.groupEnd();
+      _console.log('Back to the outer level');
+
+      expect(consoleOutput).toBe(
+        [
+          'L: This is the outer level',
+          'L: > Group 1',
+          'L: > Level 2',
+          'L: > > Group 2',
+          'L: > > Level 3',
+          'W: > > More of level 3',
+          'L: > Back to level 2',
+          'L: Back to the outer level',
+        ].join('\n') + '\n',
+      );
+    });
+  });
+
+  describe('info', () => {
+    it('should output the given text', () => {
+      _console.info(1);
+      _console.info('info');
+      expect(consoleOutput).toBe('I: 1\nI: info\n');
+    });
+
+    it('should output all of the arguments passed in', () => {
+      _console.info('something happened', 'more things');
+      _console.info({interesting: 'this is'}, '~ Yoda', 1);
+      expect(consoleOutput).toBe(
+        [
+          'I: something happened more things',
+          "I: { interesting: 'this is' } '~ Yoda' 1",
+        ].join('\n') + '\n',
+      );
+    });
+  });
+
+  describe('log', () => {
+    it('should output the given object', () => {
+      _console.log(1);
+      _console.log('log');
+      _console.log({a: 10});
+      expect(consoleOutput).toBe('L: 1\nL: log\nL: { a: 10 }\n');
+    });
+
+    it('should output all of the arguments passed in', () => {
+      _console.log('something happened', 'more things');
+      _console.log({interesting: 'this is'}, '~ Yoda', 1);
+      expect(consoleOutput).toBe(
+        [
+          'L: something happened more things',
+          "L: { interesting: 'this is' } '~ Yoda' 1",
+        ].join('\n') + '\n',
+      );
+    });
+  });
+
+  describe('table', () => {
+    it('should output nothing if an object or array is not passed in', () => {
+      _console.table();
+      _console.table('hello');
+      _console.table(3);
+      expect(consoleOutput).toBe('');
+    });
+
+    it('should print an empty table if there are no elements in the object or array', () => {
+      _console.table([]);
+      _console.table({});
+      expect(consoleOutput).toBe(
+        [
+          'L: ___________________',
+          'L: | (index) | Value |',
+          'L: |---------|-------|',
+          'L: ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾',
+          'L: ___________________',
+          'L: | (index) | Value |',
+          'L: |---------|-------|',
+          'L: ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾',
+        ].join('\n') + '\n',
+      );
+    });
+
+    it('should print each of the elements of an array on its own line', () => {
+      _console.table([{a: 1, b: 2, c: 3}, 4, 3, 2, 1]);
+      expect(consoleOutput).toBe(
+        [
+          'L: _________________________________',
+          'L: | (index) | Value               |',
+          'L: |---------|---------------------|',
+          'L: | 0       | {"a":1,"b":2,"c":3} |',
+          'L: | 1       | 4                   |',
+          'L: | 2       | 3                   |',
+          'L: | 3       | 2                   |',
+          'L: | 4       | 1                   |',
+          'L: ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾',
+        ].join('\n') + '\n',
+      );
+    });
+
+    it('should print each of the key-value pairs of an object on its own line', () => {
+      _console.table({a: 1, c: [3, 4, 3, 2, 1], reallyLongKey: 2});
+      expect(consoleOutput).toBe(
+        [
+          'L: _______________________________',
+          'L: | (index)       | Value       |',
+          'L: |---------------|-------------|',
+          'L: | a             | 1           |',
+          'L: | c             | [3,4,3,2,1] |',
+          'L: | reallyLongKey | 2           |',
+          'L: ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾',
+        ].join('\n') + '\n',
+      );
+    });
+  });
+
+  describe('warn', () => {
+    it('should output the given object', () => {
+      _console.warn(1);
+      _console.warn('warn');
+      _console.warn({a: 10});
+      expect(consoleOutput).toBe('W: 1\nW: warn\nW: { a: 10 }\n');
+    });
+
+    it('should output all of the arguments passed in', () => {
+      _console.warn('something happened', 'more things');
+      _console.warn({warning: 'this is'}, '~ Yoda', 1);
+      expect(consoleOutput).toBe(
+        [
+          'W: something happened more things',
+          "W: { warning: 'this is' } '~ Yoda' 1",
+        ].join('\n') + '\n',
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Addresses #3756. I added the following functions to `CustomConsole`:

- `assert`
- `count`
- `group`
- `groupCollapsed`
- `groupEnd`
- `table`

**Test plan**
I added an automated test for `CustomConsole` at `packages/jest-util/src/__tests__/console.test.js`. This is the output:

```
yarn run jest packages/jest-util/src/__tests__/console.test.js
yarn run v0.27.5
$ node ./packages/jest-cli/bin/jest.js "packages/jest-util/src/__tests__/console.test.js"
 PASS  packages/jest-util/src/__tests__/console.test.js (6.024s)
  CustomConsole
    inherited functions
      ✓ should exist (63ms)
    assert
      ✓ should log the given text if the assertion is false (12ms)
      ✓ should not log the given text if the assertion is true (1ms)
    count
      ✓ should output the number of times count has been called (2ms)
      ✓ should output the number of times count() has been called with a certain label (12ms)
    error/exception
      ✓ should output the error (2ms)
      ✓ should output all of the arguments passed in (23ms)
    group/groupCollapsed/groupEnd
      ✓ should indent the logs one level (3ms)
      ✓ should print the label, if given (1ms)
    info
      ✓ should output the given text (12ms)
      ✓ should output all of the arguments passed in (2ms)
    log
      ✓ should output the given object (89ms)
      ✓ should output all of the arguments passed in (2ms)
    table
      ✓ should output nothing if an object or array is not passed in (2ms)
      ✓ should print an empty table if there are no elements in the object or array (3ms)
      ✓ should print each of the elements of an array on its own line (2ms)
      ✓ should print each of the key-value pairs of an object on its own line (2ms)
    warn
      ✓ should output the given object (9ms)
      ✓ should output all of the arguments passed in (2ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        6.186s
Ran all test suites matching "packages/jest-util/src/__tests__/console.test.js".
Done in 18.82s.

```